### PR TITLE
vim-ReplaceWithRegister

### DIFF
--- a/lua/preetham/plugins-setup.lua
+++ b/lua/preetham/plugins-setup.lua
@@ -38,6 +38,7 @@ return packer.startup(function(use)
 
   -- essential plugins
   use("tpope/vim-surround") -- add, delete, change surroundings (it's awesome)
+  use("inkarkat/vim-ReplaceWithRegister") -- replace with register contents using motion (gr + motion)
 
   if packer_bootstrap then
     require("packer").sync()


### PR DESCRIPTION
Added vim-ReplaceWithRegister plugin, which takes the contents of the vim register and replaces text of your choosing with that. Use `yw` first to copy a word then `grw` to paste it. Uses `gr` + motion.