### PR TITLE
Comment.nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -4,3 +4,6 @@ require("preetham.plugins-setup")
 -- Core
 require("preetham.core.options")
 require("preetham.core.keymaps")
+
+-- Plugins
+require("preetham.plugins.comment")

--- a/lua/preetham/plugins-setup.lua
+++ b/lua/preetham/plugins-setup.lua
@@ -40,6 +40,9 @@ return packer.startup(function(use)
   use("tpope/vim-surround") -- add, delete, change surroundings (it's awesome)
   use("inkarkat/vim-ReplaceWithRegister") -- replace with register contents using motion (gr + motion)
 
+  -- commenting with gc
+  use("numToStr/Comment.nvim")
+
   if packer_bootstrap then
     require("packer").sync()
   end

--- a/lua/preetham/plugins/comment.lua
+++ b/lua/preetham/plugins/comment.lua
@@ -1,0 +1,8 @@
+-- import comment plugin safely
+local setup, comment = pcall(require, "Comment")
+if not setup then
+  return
+end
+
+-- enable comment
+comment.setup()


### PR DESCRIPTION
Added the Comment.nvim plugin which enables easy comments automatically based on the language syntax. Use `gcc` to comment and `gcc` again to uncomment.