### PR TITLE
nvim-tree

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,3 +7,4 @@ require("preetham.core.keymaps")
 
 -- Plugins
 require("preetham.plugins.comment")
+require("preetham.plugins.nvim-tree")_

--- a/init.lua
+++ b/init.lua
@@ -7,4 +7,4 @@ require("preetham.core.keymaps")
 
 -- Plugins
 require("preetham.plugins.comment")
-require("preetham.plugins.nvim-tree")_
+require("preetham.plugins.nvim-tree")

--- a/lua/preetham/plugins-setup.lua
+++ b/lua/preetham/plugins-setup.lua
@@ -45,6 +45,9 @@ return packer.startup(function(use)
   -- commenting with gc
   use("numToStr/Comment.nvim")
 
+  -- file explorer
+  use("nvim-tree/nvim-tree.lua")
+
   if packer_bootstrap then
     require("packer").sync()
   end

--- a/lua/preetham/plugins/nvim-tree.lua
+++ b/lua/preetham/plugins/nvim-tree.lua
@@ -1,0 +1,64 @@
+-- import nvim-tree plugin safely
+local setup, nvimtree = pcall(require, "nvim-tree")
+if not setup then
+  return
+end
+
+-- recommended settings from nvim-tree documentation
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
+-- change color for arrows in tree to light blue
+vim.cmd([[ highlight NvimTreeIndentMarker guifg=#3FC5FF ]])
+
+-- configure nvim-tree
+nvimtree.setup({
+  -- change folder arrow icons
+  renderer = {
+    icons = {
+      glyphs = {
+        folder = {
+          arrow_closed = "", -- arrow when folder is closed
+          arrow_open = "", -- arrow when folder is open
+        },
+      },
+    },
+  },
+  -- disable window_picker for
+  -- explorer to work well with
+  -- window splits
+  actions = {
+    open_file = {
+      window_picker = {
+        enable = false,
+      },
+    },
+  },
+  -- 	git = {
+  -- 		ignore = false,
+  -- 	},
+})
+
+-- open nvim-tree on setup
+
+local function open_nvim_tree(data)
+  -- buffer is a [No Name]
+  local no_name = data.file == "" and vim.bo[data.buf].buftype == ""
+
+  -- buffer is a directory
+  local directory = vim.fn.isdirectory(data.file) == 1
+
+  if not no_name and not directory then
+    return
+  end
+
+  -- change to the directory
+  if directory then
+    vim.cmd.cd(data.file)
+  end
+
+  -- open the tree
+  require("nvim-tree.api").tree.open()
+end
+
+vim.api.nvim_create_autocmd({ "VimEnter" }, { callback = open_nvim_tree })


### PR DESCRIPTION
Added nvim-tree plugin which serves as a file explorer. This increases development productivity and efficiency, by not having to exit the Neovim editor each time the user wanted to open another file in a different directory. At the moment, typing `:NvimTreeToggle` shows the file explorer on the left-hand side.