### PR TITLE
nvim-web-devicons

### DIFF
--- a/lua/preetham/plugins-setup.lua
+++ b/lua/preetham/plugins-setup.lua
@@ -48,6 +48,9 @@ return packer.startup(function(use)
   -- file explorer
   use("nvim-tree/nvim-tree.lua")
 
+  -- vs-code like icons
+  use("nvim-tree/nvim-web-devicons")
+
   if packer_bootstrap then
     require("packer").sync()
   end


### PR DESCRIPTION
Added nvim-web-devicons plugins, which provide VS code-like icons in the nvim-tree file explorer to differentiate between certain file extensions.